### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ mysqlclient==1.4.6
 odfpy==1.4.0
 openpyxl==3.0.1
 Pillow==6.2.1
-pkg-resources==0.0.0
 ply==3.11
 pylint==2.4.4
 pytz==2019.3


### PR DESCRIPTION
Remove pkg-resources==0.0.0 from requirements.txt as it prevents pip -r from functioning, see this Stack Overflow thread: 

https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command